### PR TITLE
fix split_network

### DIFF
--- a/changelog
+++ b/changelog
@@ -101,6 +101,8 @@ rework getclass
                 - add table tag at the end of supernets adds </table> tag at the end of supernet output when in html mode 
                 Add manpage of Nick Clifford 
                 Applied patch of Victor Engmark:
-                  Description: fixes overzealous input checking
-                  Netmask /0 is perfectly fine, with this patch it's possible to use it.
-
+                Description: fixes overzealous input checking
+                Netmask /0 is perfectly fine, with this patch it's possible to use it.
+0.51 2021-06-20 bugifx: split_network results were wrong since introduction of bignum. log function replaced
+		with loop.
+                Thanks to Christian Ebnöter for finding thix bug

--- a/contributors
+++ b/contributors
@@ -1,7 +1,9 @@
 Thanks for your ideas and help to make this tool more useful:
 
 Bartosz Fenski
+Christan Ebnöther
 Denis A. Hainsworth 
+Edward
 Foxfair Hu
 Frank Quotschalla  
 Hermann J. Beckers  
@@ -9,12 +11,11 @@ Igor Zozulya
 Kevin Ivory        
 Lars Mueller
 Lutz Pressler       
+Nick Clifford 
 Oliver Seufer
 Scott Davis         
 Steve Kent          
 Sven Anderson       
 Torgen Foertsch
 Tim Brown
-Edward
-Nick Clifford 
 Victor Engmark

--- a/ipcalc
+++ b/ipcalc
@@ -2,7 +2,7 @@
 
 
 #  IPv4 Calculator
-#  Copyright (C) Krischan Jodies 2000 - 2004
+#  Copyright (C) Krischan Jodies 2000 - 2021
 #  krischan()jodies.de, http://jodies.de/ipcalc
 #   
 #  This program is free software; you can redistribute it and/or modify
@@ -22,7 +22,7 @@
 use strict;
 use bignum;
 
-my $version = '0.5';
+my $version = '0.51';
 
 my @class   = qw (0 8 16 24 4 5 5);
 
@@ -639,7 +639,6 @@ sub split_network
    my $needed_size;
    foreach (@sizes) {
       $needed_size = round2powerof2($_+2);
-#      printf "%3d -> %3d -> %3d\n",$_,$_+2,$needed_size;
       push @network , $needed_size .":".$i++;
       $needed_addresses += $needed_size;
    }
@@ -647,7 +646,7 @@ sub split_network
    foreach (@network) {
       my ($size,$nr) = split ":",$_;
       $net[$nr]=  $network;
-      $mask[$nr]= (32-log($size)/log(2));
+      $mask[$nr]= size2bitcountmask($size);
       $network += $size;
    }
    $i = -1;
@@ -660,7 +659,7 @@ sub split_network
       printnet($net[$i],bitcountmaskton($mask[$i]),$mask2);
    }
 
-   my $used_mask = 32-log(round2powerof2($needed_addresses))/log(2);
+   my $used_mask = size2bitcountmask($needed_addresses);
    if ($used_mask < ntobitcountmask($mask1)) {
       print "Network is too small\n";
    }
@@ -677,6 +676,16 @@ sub round2powerof2 {
      $i++;
   }
   return 1 << $i;
+}
+
+sub size2bitcountmask
+{
+   my $size = shift;
+   my $i = 0;
+   while ($size > ( 1 << $i)) {
+      $i++;
+   }
+   return 32-$i;
 }
 
 # Deaggregate address range

--- a/ipcalc.cgi
+++ b/ipcalc.cgi
@@ -2,7 +2,7 @@
 
 # CGI Wrapper for IPv4 Calculator
 # 
-# Copyright (C) Krischan Jodies 2000 - 2005
+# Copyright (C) Krischan Jodies 2000 - 2021
 # krischan()jodies.de, http://jodies.de/ipcalc
 # 
 # Copyright (C) for the graphics ipcalc.gif and ipcalculator.png 
@@ -255,22 +255,24 @@ creating HTML and still works happily in /usr/local/bin/ :-)</p>
 
 <pre>
 Bartosz Fenski
-Denis A. Hainsworth
+Christan Ebnoether
+Denis A. Hainsworth 
+Edward
 Foxfair Hu
-Frank Quotschalla
-Hermann J. Beckers
-Igor Zozulya
-Kevin Ivory
+Frank Quotschalla  
+Hermann J. Beckers  
+Igor Zozulya        
+Kevin Ivory        
 Lars Mueller
-Lutz Pressler
+Lutz Pressler       
+Nick Clifford 
 Oliver Seufer
-Scott Davis
-Steve Kent
-Sven Anderson
+Scott Davis         
+Steve Kent          
+Sven Anderson       
 Torgen Foertsch
 Tim Brown
-
-
+Victor Engmark
 </pre>
                </td>
 	    </tr>
@@ -345,7 +347,7 @@ print <<"EOF";
 Have a look in the archives for the <b>new version 0.38</b>, with the capability to deaggregate network ranges<br>
 <a href="ipcalc-faq/win32.html">How to run this under windows</a><br>
 Debian users can apt-get install ipcalc<br>
-2000-2004 <a href="mailto:$MAIL_ADDRESS">Krischan Jodies</a>
+2000-2021 <a href="mailto:$MAIL_ADDRESS">Krischan Jodies</a>
 
 </td></tr></table>
 </center>


### PR DESCRIPTION
split_network results were wrong since introduction of bignum. log function replaced with loop. 