### PR TITLE
Exit with code 1 when there's an error

### DIFF
--- a/ipcalc
+++ b/ipcalc
@@ -204,7 +204,7 @@ EOF
       }
       print "$error\n";
       print set_color($norml_color);
-      exit;
+      exit 1;
    }
 
 #   print "Address: ".ntoa($address)."\n";


### PR DESCRIPTION
This makes it easier to use `ipcalc` as part of other scripts.

Before:

```
$ ipcalc foo > /dev/null ; echo $?
0
```

After:

```
$ ipcalc foo > /dev/null ; echo $?
1
```
