### PR TITLE
Detect WT_SESSION and TERM_PROGRAM environment variables

### DIFF
--- a/ipcalc
+++ b/ipcalc
@@ -742,7 +742,7 @@ sub getopts
 
    # Under Emacs, do not use colors by default. The TERM is for older
    # Emacs versions.
-   if ( !defined($ENV{'TERM'}) or $ENV{'TERM'} =~ /dumb/i  or  $ENV{'INSIDE_EMACS'} ) {
+   if ( !defined($ENV{'WT_SESSION'}) and !defined($ENV{'TERM'}) and !defined($ENV{'TERM_PROGRAM'}) or defined($ENV{'TERM'}) and $ENV{'TERM'} =~ /dumb/i  or  $ENV{'INSIDE_EMACS'} ) {
        $opt_color = 0;
    }
 


### PR DESCRIPTION
Detection for Windows Terminal (`WT_SESSION`) and other terminals such as the integrated VSCode terminal and [Hyper](https://hyper.is/) (`TERM_PROGRAM`) for Windows, since `TERM` isn't available.