### PR TITLE
Fix deaggregate failing on perl 5.38

### DIFF
--- a/ipcalc
+++ b/ipcalc
@@ -701,9 +701,10 @@ sub deaggregate
   {
        $step = 0;
        while (($base | (1 << $step))  != $base) {
-          if (($base | (((~0) & $thirtytwobits) >> (31-$step))) > $end) {
-	     last;
-	  }
+          my $mask = (((~0) & $thirtytwobits) >> (31-$step))->as_int();
+          if (($base | $mask) > $end) {
+             last;
+          }
           $step++;
        }
        print ntoa($base)."/" .(32-$step);


### PR DESCRIPTION
Workaround for a bug causing BigInt and BigFloat comparison to result in an endless loop until the fix added in https://github.com/Perl/perl5/commit/451bb38c1aff2c8c0117e969b174e0f00599e05d lands in the next Perl release.